### PR TITLE
Add send and receive timeout options on ImageSender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,13 @@ docs/source
 .Trash-*
 
 # Mac Icon file that appears in every folder
-Icon
+Icon
+
 
 # Various data files that don't need to be in the git repository
 *.npy
 *.swp
 *.log*
 *stdout*
+
+.idea

--- a/imagezmq/imagezmq.py
+++ b/imagezmq/imagezmq.py
@@ -26,7 +26,7 @@ class ImageSender():
       connect_to: the tcp address:port of the hub computer.
     """
 
-    def __init__(self, connect_to='tcp://127.0.0.1:5555'):
+    def __init__(self, connect_to='tcp://127.0.0.1:5555', send_timeout=0):
         """Initializes zmq socket for sending images to the hub.
 
         Expects an open socket at the connect_to tcp address; it will
@@ -36,6 +36,8 @@ class ImageSender():
 
         self.zmq_context = SerializingContext()
         self.zmq_socket = self.zmq_context.socket(zmq.REQ)
+        if send_timeout > 0:
+            self.zmq_socket.setsockopt(zmq.SNDTIMEO, send_timeout*1000)
         self.zmq_socket.connect(connect_to)
 
     def send_image(self, msg, image):

--- a/imagezmq/imagezmq.py
+++ b/imagezmq/imagezmq.py
@@ -26,7 +26,7 @@ class ImageSender():
       connect_to: the tcp address:port of the hub computer.
     """
 
-    def __init__(self, connect_to='tcp://127.0.0.1:5555', send_timeout=0):
+    def __init__(self, connect_to='tcp://127.0.0.1:5555', send_timeout=0, recv_timeout=0):
         """Initializes zmq socket for sending images to the hub.
 
         Expects an open socket at the connect_to tcp address; it will
@@ -38,6 +38,9 @@ class ImageSender():
         self.zmq_socket = self.zmq_context.socket(zmq.REQ)
         if send_timeout > 0:
             self.zmq_socket.setsockopt(zmq.SNDTIMEO, send_timeout*1000)
+
+        if recv_timeout > 0:
+            self.zmq_socket.setsockopt(zmq.RCVTIMEO, recv_timeout * 1000)
         self.zmq_socket.connect(connect_to)
 
     def send_image(self, msg, image):


### PR DESCRIPTION
While working through the PyImageSearch tutorial, I noticed that if I stopped the server and restarted the client would not connect.  If I added send and receive timeouts on the socket, then it gave me a chance to re-establish the connection the client and server would automatically begin to send images again.

If there is a better way to handle that - I am open to suggestions.

Thanks for this great library and I am glad Adrian posted a blog on it!